### PR TITLE
Use default value for orderbook depth in SetJob

### DIFF
--- a/QuantConnect.KrakenBrokerage.Tests/KrakenBrokerageDataQueueHandlerTests.cs
+++ b/QuantConnect.KrakenBrokerage.Tests/KrakenBrokerageDataQueueHandlerTests.cs
@@ -19,6 +19,7 @@ using QuantConnect.Brokerages.Kraken;
 using QuantConnect.Data;
 using QuantConnect.Logging;
 using QuantConnect.Data.Market;
+using QuantConnect.Configuration;
 
 namespace QuantConnect.Tests.Brokerages.Kraken
 {
@@ -77,6 +78,25 @@ namespace QuantConnect.Tests.Brokerages.Kraken
             Thread.Sleep(5000);
 
             cancelationToken.Cancel();
+        }
+
+        [Test]
+        public void SetJobUsesOrderBookDepthDefaultValue()
+        {
+            using var brokerage = new KrakenBrokerage();
+
+            var packet = new Packets.LiveNodePacket()
+            {
+                BrokerageData =
+                {
+                    { "kraken-api-key", Config.Get("kraken-api-key") },
+                    { "kraken-api-secret", Config.Get("kraken-api-secret") },
+                    { "kraken-verification-tier", Config.Get("kraken-verification-tier") }
+                }
+            };
+
+            Assert.DoesNotThrow(() => brokerage.SetJob(packet));
+            Assert.IsTrue(brokerage.IsConnected);
         }
     }
 }

--- a/QuantConnect.KrakenBrokerage/KrakenBrokerage.DataQueueHandler.cs
+++ b/QuantConnect.KrakenBrokerage/KrakenBrokerage.DataQueueHandler.cs
@@ -427,10 +427,12 @@ namespace QuantConnect.Brokerages.Kraken
         /// <param name="job">Job we're subscribing for</param>
         public void SetJob(LiveNodePacket job)
         {
-            if (!job.BrokerageData.TryGetValue("kraken-orderbook-depth", out var orderDepth))
+            var orderDepth = 10;
+            if (job.BrokerageData.TryGetValue("kraken-orderbook-depth", out var orderDepthStr))
             {
-                throw new ArgumentException($"KrakenBrokerage.SetJob(): missing value -- kraken-orderbook-depth");
+                orderDepth = orderDepthStr.ToInt32();
             }
+
             var aggregator = Composer.Instance.GetExportedValueByTypeName<IDataAggregator>(
                 Config.Get("data-aggregator", "QuantConnect.Lean.Engine.DataFeeds.AggregationManager"), forceTypeNameOnExisting: false);
 
@@ -438,7 +440,7 @@ namespace QuantConnect.Brokerages.Kraken
                 job.BrokerageData["kraken-api-key"],
                 job.BrokerageData["kraken-api-secret"],
                 job.BrokerageData["kraken-verification-tier"],
-                orderDepth.ToInt32(),
+                orderDepth,
                 null,
                 aggregator,
                 job);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Small fix to make `SetJob` use the default value for order book detph instead of throwing.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit test
Deployment

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
