### PR TITLE
Fix cash sync bug

### DIFF
--- a/QuantConnect.KrakenBrokerage/KrakenBrokerage.cs
+++ b/QuantConnect.KrakenBrokerage/KrakenBrokerage.cs
@@ -269,6 +269,8 @@ namespace QuantConnect.Brokerages.Kraken
                 /// first open a position for 0.005 ETHBTC and then open another one for
                 /// 0.003, when we request for open positions we will get two holdings:
                 /// One for ETHBTC with 0.005 and the second one for ETHBTC with 0.003.
+                ///
+                /// For more information see: https://docs.kraken.com/api/docs/rest-api/get-open-positions/
                 var krakenPosition = balance.Value.ToObject<KrakenOpenPosition>();
                 var holding = new Holding
                 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
When the holdings were deserialized, LEAN wasn't taking into account the parameter `vol_closed` (https://docs.kraken.com/api/docs/rest-api/get-open-positions/) which indicated the quantity closed in the base currency. Therefore, when an open position was partially closed, the quantity closed was never deducted. That's why at certain moment, when a cash sync was done, the difference was so high. Additionally, LEAN wasn't taking into account that Kraken API could create more than one holding for the same symbol. This PR aims to fix these bugs.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes (https://github.com/QuantConnect/Lean/issues/8010)
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change LEAN will have the correct cash amount after a cash sync
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I created three unit tests for the following cases: 
1. When a position is opened and then closed by another one.
2. When a position is opened and then closed partially by two others.
3. When two positions are opened for the same symbol.

These unit tests asserted that the bugs related with these scenarios had been fixed.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
